### PR TITLE
General fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ With ASDF, load the ASD file `cl-jschema.asd` and then load the system
 
 #### `CL-JSCHEMA:PARSE`
 
-Parse a JSON Schema. Returns an instance of `CL-JSCHEMA:JSON-SCHEMA` or throws a
+Parse a JSON Schema. Returns an instance of `CL-JSCHEMA:JSON-SCHEMA` or signals a
 condition of type `CL-JSCHEMA:INVALID-SCHEMA`.
 
 Allows parsing a string or a `CL:STREAM`. You may also supply it a previously
 parsed JSON that was parsed with `COM.INUOE.JZON:PARSE`. In any other case, a
-condition of type `CL:ERROR` is thrown.
+condition of type `CL:ERROR` is signaled.
 
 Keyword arguments:
 
@@ -73,7 +73,7 @@ are registered in the `CL-JSCHEMA` **registry**.
 #### `CL-JSCHEMA:VALIDATE`
 
 Validate a value with an instance of `CL-JSCHEMA:JSON-SCHEMA`. Returns `T` or
-throws a condition of type `CL-JSCHEMA:INVALID-JSON`.
+signals a condition of type `CL-JSCHEMA:INVALID-JSON`.
 
 Currently only supports validating values which look like they have been
 previously parsed by `COM.INUOE.JZON:PARSE`.
@@ -85,7 +85,7 @@ Keyword arguments:
   when resolving `$ref`. Can be set to non-`NIL` to consider values as valid
   when `$ref` is not resolvable.
 
-If a condition of type `CL-JSCHEMA:INVALID-JSON` is thrown, then it's possible
+If a condition of type `CL-JSCHEMA:INVALID-JSON` is signaled, then it's possible
 to access all of the validation errors found throughout the validation by using
 `CL-JSCHEMA:INVALID-JSON-ERRORS`.
 
@@ -114,37 +114,37 @@ new one or `CL-JSCHEMA:GET-SCHEMA` to find a previously parsed one.
 
 #### `CL-JSCHEMA:INVALID-SCHEMA`
 
-Conditions of this type are thrown when using `CL-JSCHEMA:PARSE`. This condition
+Conditions of this type are signaled when using `CL-JSCHEMA:PARSE`. This condition
 indicates that the JSON Schema being parsed is invalid.
 
 Information about this condition can be accessed with:
 
 * `CL-JSCHEMA:INVALID-SCHEMA-ERROR-MESSAGE`: the reason why the condition was
-  thrown. Returns a string.
+  signaled. Returns a string.
 * `CL-JSCHEMA:INVALID-SCHEMA-BASE-URI`: the base URI, if any, of the JSON Schema
-  being validated when the condition was thrown. Returns `NIL` or an instance of
+  being validated when the condition was signaled. Returns `NIL` or an instance of
   `PURI:URI`.
 * `CL-JSCHEMA:INVALID-SCHEMA-JSON-POINTER`: the [JSON
   Pointer](https://www.rfc-editor.org/rfc/rfc6901) to the value being validated
-  in the JSON Schema when the condition was thrown. The JSON Pointer is relative
+  in the JSON Schema when the condition was signaled. The JSON Pointer is relative
   to the base URI. Returns a string.
 
 #### `CL-JSCHEMA:UNPARSABLE-JSON`
 
-Conditions of this type are thrown when using `CL-JSCHEMA:PARSE`. This condition
+Conditions of this type are signaled when using `CL-JSCHEMA:PARSE`. This condition
 indicates that an error was encountered when trying to parse the JSON Schema
 JSON.
 
 This condition is a subtype of `CL-JSCHEMA:INVALID-SCHEMA`, meaning the same
 information can be accessed with the same accessors. Additionally:
 
-*  `CL-JSCHEMA:UNPARSABLE-JSON-ERROR`: the condition caught when trying to parse
+*  `CL-JSCHEMA:UNPARSABLE-JSON-ERROR`: the condition handled when trying to parse
    the JSON Schema JSON. Returns an instance of a condition of type
    `COM.INUOE.JZON:JSON-ERROR`.
 
 #### `CL-JSCHEMA:NOT-IMPLEMENTED`
 
-Conditions of this type are thrown when using `CL-JSCHEMA:PARSE`. This condition
+Conditions of this type are signaled when using `CL-JSCHEMA:PARSE`. This condition
 indicates that the JSON Schema is trying to use some property which is not
 implemented by `CL-JSCHEMA`.
 
@@ -153,26 +153,26 @@ information can be accessed with the same accessors.
 
 #### `CL-JSCHEMA:INVALID-JSON`
 
-Conditions of this type are thrown when using `CL-JSCHEMA:VALIDATE`. This
+Conditions of this type are signaled when using `CL-JSCHEMA:VALIDATE`. This
 condition indicates that the value supplied for validation is invalid.
 
 Information about this condition can be accessed with:
 
 * `CL-JSCHEMA:INVALID-JSON-ERRORS`: a list of all conditions of type
-  `CL-JSCHEMA:INVALID-JSON-VALUE` caught while validating the value supplied for
+  `CL-JSCHEMA:INVALID-JSON-VALUE` handled while validating the value supplied for
   validation.
 
 #### `CL-JSCHEMA:INVALID-JSON-VALUE`
 
-Conditions of this type are thrown yet handled internally when using
+Conditions of this type are signaled yet handled internally when using
 `CL-JSCHEMA:VALIDATE`. This condition indicates at a particular value inside the
 supplied value for validation is invalid.
 
 * `CL-JSCHEMA:INVALID-JSON-VALUE-ERROR-MESSAGE`: the reason why the condition
-  was thrown. Returns a string.
+  was signaled. Returns a string.
 * `CL-JSCHEMA:INVALID-JSON-VALUE-JSON-POINTER`: the [JSON
   Pointer](https://www.rfc-editor.org/rfc/rfc6901) to the value being validated
-  when the condition was thrown.
+  when the condition was signaled.
 
 ## Example
 

--- a/src/keywords.lisp
+++ b/src/keywords.lisp
@@ -28,8 +28,8 @@
     ;; type schema and per-type keywords
     ("type" . string-or-array-of-strings)
     ;; * string type
-    ("minLength"        . non-negative-number)
-    ("maxLength"        . non-negative-number)
+    ("minLength"        . non-negative-integer)
+    ("maxLength"        . non-negative-integer)
     ("pattern"          . regex)
     ("format"           . string)
     ("contentEncoding"  . string)
@@ -47,18 +47,18 @@
     ("unevaluatedProperties" . schema-like)
     ("required"              . array-of-strings)
     ("propertyNames"         . schema-like)
-    ("minProperties"         . non-negative-number)
-    ("maxProperties"         . non-negative-number)
+    ("minProperties"         . non-negative-integer)
+    ("maxProperties"         . non-negative-integer)
     ("dependentRequired"     . hash-table-of-array-of-strings)
     ("dependentSchemas"      . hash-table-of-schema-likes)
     ;; * array type
     ("items"       . schema-like)
     ("prefixItems" . non-empty-array-of-schema-likes)
     ("contains"    . schema-like)
-    ("minContains" . non-negative-number)
-    ("maxContains" . non-negative-number)
-    ("minItems"    . non-negative-number)
-    ("maxItems"    . non-negative-number)
+    ("minContains" . non-negative-integer)
+    ("maxContains" . non-negative-integer)
+    ("minItems"    . non-negative-integer)
+    ("maxItems"    . non-negative-integer)
     ("uniqueItems" . json-boolean)
     ;; composition
     ("allOf" . non-empty-array-of-schema-likes)
@@ -74,7 +74,7 @@
 
 (defun keyword-type (keyword)
   "Return the expected Lisp type for JSON Schema KEYWORD."
-  (cdr (assoc keyword *keyword-specs* :test 'equal)))
+  (a:assoc-value *keyword-specs* keyword :test 'equal))
 
 
 ;;; Annotations
@@ -161,11 +161,15 @@ must satisfy and JSON Schema keywords which map to the type.")
 
 (defparameter *type-keywords*
   (append (list "type")
-          (remove-duplicates (alexandria:flatten
+          (remove-duplicates (a:flatten
                               (mapcar 'type-spec-keywords *type-specs*))
                              :test 'equal))
   "The list of allowed JSON Schema keywords for defining a valid value.")
 
+;; Protect against internboming: we INTERN all keywords ahead of time,
+;; so that ADD-TO-TYPE-PROPERTIES needs to only FIND-SYMBOL at runtime.
+(dolist (keyword *type-keywords*)
+  (intern keyword :keyword))
 
 (defun type-spec (type)
   "Return the TYPE-SPEC for JSON Schema keyword TYPE."
@@ -202,6 +206,10 @@ must satisfy and JSON Schema keywords which map to the type.")
      . "Keyword ~a expects a positive number")
     (non-negative-number
      . "Keyword ~a expects a non-negative number")
+    (positive-integer
+     . "Keyword ~a expects a positive integer")
+    (non-negative-integer
+     . "Keyword ~a expects a non-negative integer")
     (simple-vector
      . "Keyword ~a expects a JSON array")
     (non-empty-array

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -1,12 +1,15 @@
 (defpackage #:cl-jschema
   (:use #:cl)
-  (:local-nicknames (#:jzon #:com.inuoe.jzon))
+  (:local-nicknames (#:jzon #:com.inuoe.jzon)
+                    (#:a #:alexandria))
   (:export
    ;; JSON Schema entrypoints
    #:parse
    #:validate
    #:clear-registry
    #:get-schema
+   #:register-schema
+   #:unregister-schema
    ;; JSON Schema object
    #:json-schema
    ;; Invalid JSON Schema conditions

--- a/src/parse.lisp
+++ b/src/parse.lisp
@@ -73,7 +73,7 @@
 
 (defun check-keyword-value-type (keyword value)
   "Check if VALUE fulfills KEYWORD's Lisp type. Return T if so."
-  (alexandria:when-let ((type (keyword-type keyword)))
+  (a:when-let ((type (keyword-type keyword)))
     (cond
       ((equal keyword "type")
        (check-type-value value))
@@ -116,12 +116,9 @@
 
 
 (defun parse-regex (string)
-  (handler-case
-      (make-instance 'regex-box
-                     :regex-string string
-                     :regex (ppcre:create-scanner string))
-    (ppcre:ppcre-syntax-error ()
-      (raise-invalid-schema "This regex is not valid: ~a" string))))
+  (make-instance 'regex-box
+                 :regex-string string
+                 :regex (ppcre:create-scanner string)))
 
 
 (defun parse-pattern-properties (json-object)
@@ -196,7 +193,7 @@ If successful, also remove the KEYWORD from the JSON-OBJECT."
 (defun check-colliding-type-keywords (type-properties)
   "Check if any of the keywords in TYPE-PROPERTIES refer to different types of
 JSON values."
-  (let* ((props (alexandria:hash-table-values type-properties))
+  (let* ((props (a:hash-table-values type-properties))
          (type-prop (find "type" props :key 'key :test 'equal))
          (type (when type-prop (value type-prop)))
          (keywords (mapcar 'key
@@ -210,7 +207,7 @@ JSON values."
                 (raise-invalid-schema "Keyword ~a is for type ~a, not for type ~a"
                                       keyword kw-type type)))))
         (dolist (keyword keywords)
-          (alexandria:when-let ((kw-type (type-for-keyword keyword)))
+          (a:when-let ((kw-type (type-for-keyword keyword)))
             (dolist (other-keyword keywords)
               (unless (or (equal keyword other-keyword)
                           (equal kw-type (type-for-keyword other-keyword)))
@@ -244,7 +241,7 @@ JSON values."
                          for keyword-prop being the hash-values in type-properties
                            thereis (type-for-keyword (key keyword-prop))))))
         (when type
-          (make-instance (alexandria:switch (type :test 'equal)
+          (make-instance (a:switch (type :test 'equal)
                            ("object" 'json-object-schema)
                            ("array"  'json-array-schema)
                            (t        'json-basic-type-schema))
@@ -284,7 +281,7 @@ JSON values."
                              :operator keyword
                              ;; 'not' expects a JSON schema. Let's ensure we
                              ;; use a list here for easier validation.
-                             :schemas (alexandria:ensure-list
+                             :schemas (a:ensure-list
                                        (parse-keyword-value keyword value
                                                             json-object)))))
 

--- a/src/registry.lisp
+++ b/src/registry.lisp
@@ -4,13 +4,18 @@
 (defvar *registry* (make-hash-table :test 'equal)
   "Map of URI-reference strings to 'JSON-SCHEMA objects")
 
+;;; Entrypoints
 
+;; TODO make registration optional.
 (defun register-schema (id json-schema)
   "Store JSON-SCHEMA in the registry with id ID."
   (setf (gethash id *registry*) json-schema))
 
 
-;;; Entrypoints
+(defun unregister-schema (id)
+  "Remove the JSON-SCHEMA with the provided ID from the registry."
+  (remhash id *registry*))
+
 
 (defun clear-registry ()
   "Clear the registry of parsed JSON Schemas."

--- a/src/types.lisp
+++ b/src/types.lisp
@@ -27,7 +27,7 @@
     (hash-table-of-type-p hash-table 'schema-like)))
 
 (deftype hash-table-of-schema-likes ()
-  `(and hash-table (satisfies hash-table-of-schema-likes-p)))
+  '(and hash-table (satisfies hash-table-of-schema-likes-p)))
 
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
@@ -35,7 +35,7 @@
     (hash-table-of-type-p hash-table 'array-of-strings)))
 
 (deftype hash-table-of-array-of-strings ()
-  `(and hash-table (satisfies hash-table-of-array-of-strings-p)))
+  '(and hash-table (satisfies hash-table-of-array-of-strings-p)))
 
 
 ;;; JSON arrays
@@ -46,7 +46,7 @@
          (plusp (length array)))))
 
 (deftype non-empty-array ()
-  `(and simple-vector (satisfies non-empty-array-p)))
+  '(and simple-vector (satisfies non-empty-array-p)))
 
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
@@ -54,7 +54,7 @@
     (array-of-type-p array 'string)))
 
 (deftype array-of-strings ()
-  `(and simple-vector (satisfies array-of-strings-p)))
+  '(and simple-vector (satisfies array-of-strings-p)))
 
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
@@ -62,7 +62,7 @@
     (array-of-type-p array 'hash-table)))
 
 (deftype array-of-hash-tables ()
-  `(and simple-vector (satisfies array-of-hash-tables-p)))
+  '(and simple-vector (satisfies array-of-hash-tables-p)))
 
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
@@ -70,28 +70,28 @@
     (array-of-type-p array 'schema-like)))
 
 (deftype non-empty-array-of-schema-likes ()
-  `(and non-empty-array (satisfies array-of-schema-likes-p)))
+  '(and non-empty-array (satisfies array-of-schema-likes-p)))
 
 
 ;;; JSON symbols
 
 (deftype json-null ()
-  `(satisfies json-null-p))
+  '(eql null))
 
 (deftype json-true ()
-  `(satisfies json-true-p))
+  '(eql t))
 
 (deftype json-false ()
-  `(satisfies json-false-p))
+  '(eql nil))
 
 (deftype json-boolean ()
-  `(or json-true json-false))
+  '(or json-true json-false))
 
 
 ;;; JSON Schema
 
 (deftype schema-like ()
-  `(or json-boolean hash-table))
+  '(or json-boolean hash-table))
 
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
@@ -101,7 +101,7 @@
          (json-true-p (schema-spec json-schema)))))
 
 (deftype json-true-schema ()
-  `(and json-schema (satisfies json-true-schema-p)))
+  '(and json-schema (satisfies json-true-schema-p)))
 
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
@@ -111,13 +111,13 @@
          (json-false-p (schema-spec json-schema)))))
 
 (deftype json-false-schema ()
-  `(and json-schema (satisfies json-false-schema-p)))
+  '(and json-schema (satisfies json-false-schema-p)))
 
 
 ;;; Others / helpers
 
 (deftype string-or-array-of-strings ()
-  `(or string array-of-strings))
+  '(or string array-of-strings))
 
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
@@ -128,29 +128,32 @@
              (zerop (mod value 1))))))
 
 (deftype integer-like ()
-  `(satisfies integer-like-p))
+  '(satisfies integer-like-p))
 
-
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (defun positive-number-p (value)
-    (and (numberp value)
-         (plusp value))))
 
 (deftype positive-number ()
-  `(and number (satisfies positive-number-p)))
+  '(real (0)))
 
-
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (defun non-negative-number-p (value)
-    (and (numberp value)
-         (>= value 0))))
 
 (deftype non-negative-number ()
-  `(and number (satisfies non-negative-number-p)))
+  '(real 0))
 
+
+(deftype positive-integer ()
+  '(integer (0)))
+
+
+(deftype non-negative-integer ()
+  '(integer 0))
+
+
+(defun regexp (x)
+  (and (stringp x)
+       (handler-case (cl-ppcre:parse-string x)
+         (cl-ppcre:ppcre-syntax-error () nil))))
 
 (deftype regex ()
-  `(and string))
+  '(and string (satisfies regexp)))
 
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
@@ -160,7 +163,7 @@
          (not (null (ignore-errors (puri:parse-uri value)))))))
 
 (deftype uri-reference ()
-  `(and string (satisfies uri-reference-p)))
+  '(and string (satisfies uri-reference-p)))
 
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
@@ -169,7 +172,7 @@
          (null (puri:uri-fragment (puri:parse-uri value))))))
 
 (deftype uri-reference-without-fragment ()
-  `(and uri-reference (satisfies uri-reference-without-fragment-p)))
+  '(and uri-reference (satisfies uri-reference-without-fragment-p)))
 
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
@@ -182,4 +185,4 @@
                      value))))
 
 (deftype anchor-like ()
-  `(and string (satisfies anchor-like-p)))
+  '(and string (satisfies anchor-like-p)))

--- a/src/validate.lisp
+++ b/src/validate.lisp
@@ -25,7 +25,8 @@ Also create an restart named 'CONTINUE-VALIDATING."
     (with-simple-restart (continue-validating "Continue validating the JSON")
       (error 'invalid-json-value
              :error-message (format nil format-message value)
-             :json-pointer (tracked-json-pointer)))))
+             :json-pointer (tracked-json-pointer)))
+    t))
 
 
 (define-condition unresolvable-ref (invalid-json-value) ())

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -1,3 +1,4 @@
 (defpackage #:cl-jschema/tests
   (:use #:cl)
-  (:local-nicknames (#:jzon #:com.inuoe.jzon)))
+  (:local-nicknames (#:jzon #:com.inuoe.jzon)
+                    (#:a #:alexandria)))

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -113,7 +113,7 @@
                                    ,(expected-message "" "pattern" regex))
                                   ("(800)FLOWERS"
                                    ,(expected-message "" "pattern" regex)))))
-  (signals cl-jschema:invalid-schema "\"/pattern\" : This regex is not valid: [0-a"
+  (signals cl-jschema:invalid-schema "\"/pattern\" : Keyword pattern expects a regular expression"
     (cl-jschema:parse "{\"pattern\": \"[0-a\"}")))
 
 
@@ -1436,13 +1436,13 @@
                   ("{\"type\":42}"
                    "\"/type\" : The value for \"type\" must be a string or an array")
                   ("{\"minLength\":\"2\"}"
-                   "\"/minLength\" : Keyword minLength expects a non-negative number")
+                   "\"/minLength\" : Keyword minLength expects a non-negative integer")
                   ("{\"minLength\":-1}"
-                   "\"/minLength\" : Keyword minLength expects a non-negative number")
+                   "\"/minLength\" : Keyword minLength expects a non-negative integer")
                   ("{\"maxLength\":\"3\"}"
-                   "\"/maxLength\" : Keyword maxLength expects a non-negative number")
+                   "\"/maxLength\" : Keyword maxLength expects a non-negative integer")
                   ("{\"maxLength\":-1}"
-                   "\"/maxLength\" : Keyword maxLength expects a non-negative number")
+                   "\"/maxLength\" : Keyword maxLength expects a non-negative integer")
                   ("{\"pattern\":42}"
                    "\"/pattern\" : Keyword pattern expects a regular expression")
                   ("{\"format\":42}"
@@ -1476,13 +1476,13 @@
                   ("{\"propertyNames\":42}"
                    "\"/propertyNames\" : Keyword propertyNames expects a schema")
                   ("{\"minProperties\":\"2\"}"
-                   "\"/minProperties\" : Keyword minProperties expects a non-negative number")
+                   "\"/minProperties\" : Keyword minProperties expects a non-negative integer")
                   ("{\"minProperties\":-1}"
-                   "\"/minProperties\" : Keyword minProperties expects a non-negative number")
+                   "\"/minProperties\" : Keyword minProperties expects a non-negative integer")
                   ("{\"maxProperties\":\"3\"}"
-                   "\"/maxProperties\" : Keyword maxProperties expects a non-negative number")
+                   "\"/maxProperties\" : Keyword maxProperties expects a non-negative integer")
                   ("{\"maxProperties\":-1}"
-                   "\"/maxProperties\" : Keyword maxProperties expects a non-negative number")
+                   "\"/maxProperties\" : Keyword maxProperties expects a non-negative integer")
                   ("{\"items\": 42}"
                    "\"/items\" : Keyword items expects a schema")
                   ("{\"prefixItems\":42}"
@@ -1490,21 +1490,21 @@
                   ("{\"prefixItems\":[42]}"
                    "\"/prefixItems\" : Keyword prefixItems expects a non-empty JSON array of schemas")
                   ("{\"minContains\":\"2\"}"
-                   "\"/minContains\" : Keyword minContains expects a non-negative number")
+                   "\"/minContains\" : Keyword minContains expects a non-negative integer")
                   ("{\"minContains\":-1}"
-                   "\"/minContains\" : Keyword minContains expects a non-negative number")
+                   "\"/minContains\" : Keyword minContains expects a non-negative integer")
                   ("{\"maxContains\":\"3\"}"
-                   "\"/maxContains\" : Keyword maxContains expects a non-negative number")
+                   "\"/maxContains\" : Keyword maxContains expects a non-negative integer")
                   ("{\"maxContains\":-1}"
-                   "\"/maxContains\" : Keyword maxContains expects a non-negative number")
+                   "\"/maxContains\" : Keyword maxContains expects a non-negative integer")
                   ("{\"minItems\":\"2\"}"
-                   "\"/minItems\" : Keyword minItems expects a non-negative number")
+                   "\"/minItems\" : Keyword minItems expects a non-negative integer")
                   ("{\"minItems\":-1}"
-                   "\"/minItems\" : Keyword minItems expects a non-negative number")
+                   "\"/minItems\" : Keyword minItems expects a non-negative integer")
                   ("{\"maxItems\":\"3\"}"
-                   "\"/maxItems\" : Keyword maxItems expects a non-negative number")
+                   "\"/maxItems\" : Keyword maxItems expects a non-negative integer")
                   ("{\"maxItems\":-1}"
-                   "\"/maxItems\" : Keyword maxItems expects a non-negative number")
+                   "\"/maxItems\" : Keyword maxItems expects a non-negative integer")
                   ("{\"uniqueItems\":42}"
                    "\"/uniqueItems\" : Keyword uniqueItems expects a boolean")
                   ("{\"title\":42}"


### PR DESCRIPTION
Depends on #8 

* Terminology: s/throw/signal/g
* Pre-`intern` at comptime and use `find-symbol` at runtime instead
* Use `(setf foo)` instead of `slot-value`
* Add package-local nickname `#:a` for Alexandria
* Fix properties that need non-negative integers, not non-negative numbers
* Move regex validation to schema creation time and strengthen regex typechecking
* Export `register-schema`
* Add `unregister-schema`
* Use quote instead of backquote where possible
* Use Lisp types instead of `satisfies` ones where possible
* Restarts: s/continue-validating/continue/g
* Remove `tests::*debug-tests*` since `5am:*on-error*` already exists
* Rewrite `tests::signals` to evaluate the body only once
* Fix tests as appropriate
